### PR TITLE
Version update

### DIFF
--- a/projection/proofs/chor_to_pchorProofScript.sml
+++ b/projection/proofs/chor_to_pchorProofScript.sml
@@ -4,6 +4,7 @@ open pchorLangTheory pchorSemTheory
 open chorConfluenceTheory chorSyncPropsTheory choreoUtilsTheory
 
 val _ = new_theory "chor_to_pchorProof"
+
 (*
 Definition ptag_def:
   ptag (chorSem$LTau p n)      = (pchorSem$LTau p n)
@@ -122,4 +123,5 @@ Proof
   \\ asm_exists_tac \\ fs []
 QED
 *)
+
 val _ = export_theory ()

--- a/projection/proofs/to_cake/chorLibProgScript.sml
+++ b/projection/proofs/to_cake/chorLibProgScript.sml
@@ -4,6 +4,8 @@ open preamble chorLangTheory chorSemTheory projectionTheory
 
 val _ = new_theory "chorLibProg";
 
+val _ = temp_delsimps ["NORMEQ_CONV"];
+    
 val _ = translation_extends "basisProg";
 
 fun get_fun_name trm =

--- a/projection/proofs/to_cake/payload_to_cakemlProofScript.sml
+++ b/projection/proofs/to_cake/payload_to_cakemlProofScript.sml
@@ -22,6 +22,8 @@ open evaluateTheory terminationTheory ml_translatorTheory
 
 val _ = new_theory "payload_to_cakemlProof";
 
+val _ = temp_delsimps ["NORMEQ_CONV"];
+
 infixr 1 $
 
 val _ = set_grammar_ancestry

--- a/semantics/proofs/endpointPropsScript.sml
+++ b/semantics/proofs/endpointPropsScript.sml
@@ -2,6 +2,8 @@ open preamble choreoUtilsTheory endpointSemTheory endpointLangTheory;
 
 val _ = new_theory "endpointProps"
 
+ val _ = temp_delsimps ["NORMEQ_CONV"]
+
 val trans_enqueue' = Q.store_thm("trans_enqueue'",
   `∀s d p1 p2 e q.
      p1 ≠ p2


### PR DESCRIPTION
These commits update the proof scripts and code generation to work on more recent CakeML and HOL version. Specifically, CakeML commit 45c65a8d and HOL4 commit 95c3c210.

@agomezl what needs to be done to update the testing infrastructure to run on these version?